### PR TITLE
本番正規URLをwwwドメインに統一

### DIFF
--- a/app/faq/layout.tsx
+++ b/app/faq/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'よくある質問 - ガタレビュ！',
     description: 'ガタレビュ！についてよくある質問をまとめました。新潟大学の授業レビューサイトの使い方や機能について詳しく解説。',
-    url: 'https://gatareview.com/faq',
+    url: 'https://www.gatareview.com/faq',
     siteName: 'ガタレビュ！',
     images: [
       {
@@ -53,4 +53,4 @@ export default function FAQLayout({
   children: React.ReactNode
 }) {
   return <>{children}</>
-} 
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,7 +16,7 @@ const PWAInstall = dynamic(() => import('./_components/PWAInstall'), {
 const inter = Inter({ subsets: ['latin'] })
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NODE_ENV === 'production' ? 'https://gatareview.com' : 'http://localhost:3000'),
+  metadataBase: new URL(process.env.NODE_ENV === 'production' ? 'https://www.gatareview.com' : 'http://localhost:3000'),
   title: 'ガタレビュ！ - 新潟大学の授業レビューサイト',
   description: '新潟大学生のための授業レビューサイトです。シラバスではわからないリアルな授業情報を共有しましょう。履修選択に役立つ学生の生の声をお届けします。',
   keywords: [
@@ -121,7 +121,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: 'ガタレビュ！ - 新潟大学の授業レビューサイト',
     description: '新潟大学生のための授業レビューサイト。シラバスではわからないリアルな授業情報を学生同士で共有。履修選択に役立つ詳細な授業評価とレビューを提供します。',
-    url: 'https://gatareview.com',
+    url: 'https://www.gatareview.com',
     siteName: 'ガタレビュ！',
     images: [
       {
@@ -150,9 +150,9 @@ export const metadata: Metadata = {
     site: '@gatareview',
   },
   alternates: {
-    canonical: 'https://gatareview.com',
+    canonical: 'https://www.gatareview.com',
     languages: {
-      'ja-JP': 'https://gatareview.com',
+      'ja-JP': 'https://www.gatareview.com',
     },
   },
   category: 'education',
@@ -206,18 +206,18 @@ export default function RootLayout({
               {
                 '@context': 'https://schema.org',
                 '@type': 'WebSite',
-                '@id': 'https://gatareview.com/#website',
+                '@id': 'https://www.gatareview.com/#website',
                 name: 'ガタレビュ！',
                 description: '新潟大学生のための授業レビューサイト',
-                url: 'https://gatareview.com',
+                url: 'https://www.gatareview.com',
                 inLanguage: 'ja-JP',
                 publisher: {
                   '@type': 'Organization',
-                  '@id': 'https://gatareview.com/#organization',
+                  '@id': 'https://www.gatareview.com/#organization',
                 },
                 potentialAction: {
                   '@type': 'SearchAction',
-                  target: 'https://gatareview.com/lectures?search={search_term_string}',
+                  target: 'https://www.gatareview.com/lectures?search={search_term_string}',
                   'query-input': 'required name=search_term_string',
                 },
               },
@@ -225,13 +225,13 @@ export default function RootLayout({
               {
                 '@context': 'https://schema.org',
                 '@type': 'Organization',
-                '@id': 'https://gatareview.com/#organization',
+                '@id': 'https://www.gatareview.com/#organization',
                 name: 'ガタレビュ運営チーム',
                 description: '新潟大学生のための授業レビューサイト運営',
-                url: 'https://gatareview.com',
+                url: 'https://www.gatareview.com',
                 logo: {
                   '@type': 'ImageObject',
-                  url: 'https://gatareview.com/icon.png',
+                  url: 'https://www.gatareview.com/icon.png',
                   width: 180,
                   height: 180,
                 },
@@ -260,14 +260,14 @@ export default function RootLayout({
               {
                 '@context': 'https://schema.org',
                 '@type': 'EducationalOrganization',
-                '@id': 'https://gatareview.com/#educationalorg',
+                '@id': 'https://www.gatareview.com/#educationalorg',
                 name: 'ガタレビュ！',
                 description: '新潟大学生のための授業レビューサイト',
-                url: 'https://gatareview.com',
-                logo: 'https://gatareview.com/icon.png',
+                url: 'https://www.gatareview.com',
+                logo: 'https://www.gatareview.com/icon.png',
                 mainEntityOfPage: {
                   '@type': 'WebPage',
-                  '@id': 'https://gatareview.com',
+                  '@id': 'https://www.gatareview.com',
                 },
                 audience: {
                   '@type': 'EducationalAudience',
@@ -276,7 +276,7 @@ export default function RootLayout({
                 },
                 provider: {
                   '@type': 'Organization',
-                  '@id': 'https://gatareview.com/#organization',
+                  '@id': 'https://www.gatareview.com/#organization',
                 },
                 offers: {
                   '@type': 'Offer',
@@ -303,19 +303,19 @@ export default function RootLayout({
                     '@type': 'ListItem',
                     position: 1,
                     name: 'ホーム',
-                    item: 'https://gatareview.com',
+                    item: 'https://www.gatareview.com',
                   },
                   {
                     '@type': 'ListItem',
                     position: 2,
                     name: '授業レビュー',
-                    item: 'https://gatareview.com/lectures',
+                    item: 'https://www.gatareview.com/lectures',
                   },
                   {
                     '@type': 'ListItem',
                     position: 3,
                     name: 'よくある質問',
-                    item: 'https://gatareview.com/faq',
+                    item: 'https://www.gatareview.com/faq',
                   },
                 ],
               },

--- a/app/lectures/[id]/layout.tsx
+++ b/app/lectures/[id]/layout.tsx
@@ -14,7 +14,7 @@ export async function generateMetadata({ params }: { params: { id: string } }): 
   const title = `${lecture.title} - ${lecture.lecturer} | ガタレビュ！`;
   const description = `${lecture.faculty}の「${lecture.title}」(${lecture.lecturer} 先生)の授業レビュー。平均評価${lecture.avg_rating?.toFixed(1) || '0.0'}点、${lecture.review_count || 0}件のレビューを確認できます。`;
 
-  const baseUrl = process.env.NODE_ENV === 'production' ? 'https://gatareview.com' : 'http://localhost:8080';
+  const baseUrl = process.env.NODE_ENV === 'production' ? 'https://www.gatareview.com' : 'http://localhost:8080';
 
   return {
     title,

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next'
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://gatareview.com'
+  const baseUrl = 'https://www.gatareview.com'
 
   // 静的なページ
   const staticPages = [

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,7 +13,7 @@ Disallow: /admin/
 Disallow: *.json$
 
 # サイトマップの場所を指定
-Sitemap: https://gatareview.com/sitemap.xml
+Sitemap: https://www.gatareview.com/sitemap.xml
 
 # クロール頻度の調整
 Crawl-delay: 1 


### PR DESCRIPTION
## 概要

本番サイトの正規URLを `https://www.gatareview.com` として扱うため、frontend 側の SEO / OGP / sitemap / robots のURL表記を www ドメインに統一しました。

## 変更範囲

- `metadataBase`, `openGraph.url`, canonical, language alternate を `https://www.gatareview.com` に変更
- JSON-LD の `@id`, `url`, `target`, Breadcrumb `item`, `logo` を www ドメインに変更
- `sitemap.ts` の `baseUrl` と `robots.txt` の `Sitemap` を www ドメインに変更
- FAQ / 講義詳細メタデータの本番URLを www ドメインに変更

## 確認

- `rg -n "https://gatareview\\.com" gatareview-front/app gatareview-front/public gatareview-back/app/views/layouts/application.html.erb` で対象範囲に root ドメインの正規URL表記が残っていないことを確認
- `npm run lint` 成功
  - 既存の ESLint warning は残存
- `npm run build` 成功
  - 既存 warning と、ローカル build 時の `gatareview-back` 名前解決失敗ログは出るが終了コードは 0
- `curl -I https://gatareview.com` で `308` により `https://www.gatareview.com/` へ転送されることを確認
- `curl -I https://www.gatareview.com` で `200` を確認

## 補足

- `contact@gatareview.com` はメールアドレスなので変更対象外
- `next.config.js` の画像許可ドメインや backend CORS の root ドメイン許可は、正規URL表記ではなく互換性設定なので変更対象外
- スクリーンショットはありません（SEOメタデータ / sitemap / robots の表記変更のみ）